### PR TITLE
Fix fuzzy matching round 2

### DIFF
--- a/cmd/subcommands/get.go
+++ b/cmd/subcommands/get.go
@@ -61,7 +61,7 @@ func getTotpKey(search string, dataMap *map[string]string, exact bool) (string, 
 
 	score, name := -1, ""
 	for n := range *dataMap {
-		if v := fuzzy.PartialRatio(search, n); v > score {
+		if v := fuzzy.Ratio(search, n); v > score {
 			score = v
 			name = n
 		}

--- a/config/main.go
+++ b/config/main.go
@@ -33,7 +33,7 @@ type ConfigF struct {
 func init() {
 	SetDefaults()
 	ConfigLoaded, _ = LoadConfigFile(ConfigFile)
-	Version = "1.2.0"
+	Version = "1.2.1"
 }
 
 func LoadConfigFile(configFile string) (bool, error) {


### PR DESCRIPTION
Bugfixes:
- Fixed matching so that it's applied to the entire string instead of substring (`PartialRatio` vs `Ratio)